### PR TITLE
feat: allow skipping unsupported

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,4 +1,4 @@
 mod translations;
 mod types_;
 
-pub use translations::{webidl_to_wit, ConversionOptions};
+pub use translations::{webidl_to_wit, ConversionOptions, HandleUnsupported};

--- a/src/translations.rs
+++ b/src/translations.rs
@@ -16,9 +16,10 @@ pub struct ConversionOptions {
     pub unsupported_features: HandleUnsupported,
 }
 
-#[derive(Clone, Debug)]
+#[derive(Clone, Debug, Default)]
 pub enum HandleUnsupported {
     /// Bail on unsupported features (default)
+    #[default]
     Bail,
     /// Skip unsupported features
     Skip,
@@ -31,7 +32,7 @@ impl Default for ConversionOptions {
         Self {
             package_name: wit_encoder::PackageName::new("my-namespace", "my-package", None),
             interface: wit_encoder::Interface::new(Some("my-interface")),
-            unsupported_features: HandleUnsupported::Bail,
+            unsupported_features: HandleUnsupported::default(),
         }
     }
 }

--- a/tests/inputs/unsupported.idl
+++ b/tests/inputs/unsupported.idl
@@ -1,0 +1,44 @@
+[Exposed=Window]
+interface NodeList {
+  getter Node? item(unsigned long index);
+  readonly attribute unsigned long length;
+  iterable<Node>;
+};
+
+[Exposed=Window]
+interface HTMLElement : Element {
+  [HTMLConstructor] constructor();
+
+  // metadata attributes
+  [CEReactions] attribute DOMString title;
+  [CEReactions] attribute DOMString lang;
+  [CEReactions] attribute boolean translate;
+  [CEReactions] attribute DOMString dir;
+
+  // user interaction
+  [CEReactions] attribute (boolean or unrestricted double or DOMString)? hidden;
+  [CEReactions] attribute boolean inert;
+  undefined click();
+  [CEReactions] attribute DOMString accessKey;
+  readonly attribute DOMString accessKeyLabel;
+  [CEReactions] attribute boolean draggable;
+  [CEReactions] attribute boolean spellcheck;
+  [CEReactions] attribute DOMString writingSuggestions;
+  [CEReactions] attribute DOMString autocapitalize;
+
+  [CEReactions] attribute [LegacyNullToEmptyString] DOMString innerText;
+  [CEReactions] attribute [LegacyNullToEmptyString] DOMString outerText;
+
+  ElementInternals attachInternals();
+
+  // The popover API
+  undefined showPopover();
+  undefined hidePopover();
+  boolean togglePopover(optional boolean force);
+  [CEReactions] attribute DOMString? popover;
+};
+
+[Exposed=Window]
+interface HTMLUnknownElement : HTMLElement {
+  // Note: intentionally no [HTMLConstructor]
+};

--- a/tests/inputs/unsupported.wit
+++ b/tests/inputs/unsupported.wit
@@ -1,0 +1,52 @@
+package my-namespace:my-package;
+
+interface my-interface {
+    resource node-list {
+        item: func(index: u32) -> option<node>;
+        length: func() -> u32;
+    }
+    resource html-element {
+        constructor();
+        title: func() -> string;
+        set-title: func(title: string);
+        lang: func() -> string;
+        set-lang: func(lang: string);
+        translate: func() -> bool;
+        set-translate: func(translate: bool);
+        dir: func() -> string;
+        set-dir: func(dir: string);
+        hidden: func() -> bool-or-f64-or-string;
+        set-hidden: func(hidden: bool-or-f64-or-string);
+        inert: func() -> bool;
+        set-inert: func(inert: bool);
+        click: func();
+        access-key: func() -> string;
+        set-access-key: func(access-key: string);
+        access-key-label: func() -> string;
+        draggable: func() -> bool;
+        set-draggable: func(draggable: bool);
+        spellcheck: func() -> bool;
+        set-spellcheck: func(spellcheck: bool);
+        writing-suggestions: func() -> string;
+        set-writing-suggestions: func(writing-suggestions: string);
+        autocapitalize: func() -> string;
+        set-autocapitalize: func(autocapitalize: string);
+        inner-text: func() -> string;
+        set-inner-text: func(inner-text: string);
+        outer-text: func() -> string;
+        set-outer-text: func(outer-text: string);
+        attach-internals: func() -> element-internals;
+        show-popover: func();
+        hide-popover: func();
+        toggle-popover: func(force: option<bool>) -> bool;
+        popover: func() -> string;
+        set-popover: func(popover: string);
+    }
+    variant bool-or-f64-or-string {
+        %bool(bool),
+        f64(f64),
+        %string(string),
+    }
+    resource html-unknown-element {
+    }
+}

--- a/tests/smoke.rs
+++ b/tests/smoke.rs
@@ -1,14 +1,14 @@
 use pretty_assertions::assert_eq;
+use webidl2wit::{ConversionOptions, HandleUnsupported};
 use std::{fs, path::Path};
 
-fn compare(path: &str) {
+fn compare(path: &str, opts: ConversionOptions) {
     let webidl_input =
         fs::read_to_string(Path::new(&format!("./tests/inputs/{path}.idl"))).unwrap();
     let wit_input = fs::read_to_string(Path::new(&format!("./tests/inputs/{path}.wit"))).unwrap();
 
     let webidl_ast = weedle::parse(&webidl_input).unwrap();
-    let wit_ast =
-        webidl2wit::webidl_to_wit(webidl_ast, webidl2wit::ConversionOptions::default()).unwrap();
+    let wit_ast = webidl2wit::webidl_to_wit(webidl_ast, opts).unwrap();
     let wit_output = wit_ast.to_string();
 
     assert_eq!(wit_input, wit_output)
@@ -16,30 +16,39 @@ fn compare(path: &str) {
 
 #[test]
 fn enum_() {
-    compare("enum");
+    compare("enum", Default::default());
 }
 
 #[test]
 fn resource() {
-    compare("resource");
+    compare("resource", Default::default());
 }
 
 #[test]
 fn record() {
-    compare("record");
+    compare("record", Default::default());
 }
 
 #[test]
 fn type_() {
-    compare("type");
+    compare("type", Default::default());
 }
 
 #[test]
 fn borrow() {
-    compare("borrow");
+    compare("borrow", Default::default());
 }
 
 #[test]
 fn webgpu() {
-    compare("webgpu");
+    compare("webgpu", Default::default());
+}
+
+#[test]
+fn unsupported() {
+    compare("unsupported", ConversionOptions {
+        package_name: wit_encoder::PackageName::new("my-namespace", "my-package", None),
+        interface: wit_encoder::Interface::new(Some("my-interface")),
+        unsupported_features: HandleUnsupported::Warn,
+    });
 }

--- a/tests/smoke.rs
+++ b/tests/smoke.rs
@@ -1,6 +1,6 @@
 use pretty_assertions::assert_eq;
-use webidl2wit::{ConversionOptions, HandleUnsupported};
 use std::{fs, path::Path};
+use webidl2wit::{ConversionOptions, HandleUnsupported};
 
 fn compare(path: &str, opts: ConversionOptions) {
     let webidl_input =
@@ -46,9 +46,11 @@ fn webgpu() {
 
 #[test]
 fn unsupported() {
-    compare("unsupported", ConversionOptions {
-        package_name: wit_encoder::PackageName::new("my-namespace", "my-package", None),
-        interface: wit_encoder::Interface::new(Some("my-interface")),
-        unsupported_features: HandleUnsupported::Warn,
-    });
+    compare(
+        "unsupported",
+        ConversionOptions {
+            unsupported_features: HandleUnsupported::Bail,
+            ..Default::default()
+        },
+    );
 }


### PR DESCRIPTION
Allows skipping unsupported items with a new `unsupported_features` option, which by default remains `Bail` but can be set to `Warn` and `Skip`.