### PR TITLE
feat: top-level world convention

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -88,7 +88,8 @@ dependencies = [
 [[package]]
 name = "weedle"
 version = "0.13.0"
-source = "git+https://github.com/rustwasm/weedle.git#260752d8b88759e708608241139449cf016088ff"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bfde6c0c0dc6d6c8b4f13afc35b46793e5a62890bcafa1a9d4c2c2301fa2f829"
 dependencies = [
  "nom",
 ]

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -96,7 +96,7 @@ dependencies = [
 [[package]]
 name = "wit-encoder"
 version = "0.212.0"
-source = "git+https://github.com/bytecodealliance/wasm-tools.git?branch=wit-encoder-use#3f9d1d8c11723204946e122c2d86503e8a90ce2d"
+source = "git+https://github.com/bytecodealliance/wasm-tools.git?branch=wit-encoder-use#860f8113bbdfc6c776f243e4fc2a639ac33e739d"
 dependencies = [
  "pretty_assertions",
  "semver",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -96,7 +96,7 @@ dependencies = [
 [[package]]
 name = "wit-encoder"
 version = "0.212.0"
-source = "git+https://github.com/bytecodealliance/wasm-tools.git?branch=wit-encoder-use#860f8113bbdfc6c776f243e4fc2a639ac33e739d"
+source = "git+https://github.com/bytecodealliance/wasm-tools.git#a265ec17ab8ee9081e9390387eafda7d92107f27"
 dependencies = [
  "pretty_assertions",
  "semver",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -96,7 +96,7 @@ dependencies = [
 [[package]]
 name = "wit-encoder"
 version = "0.212.0"
-source = "git+https://github.com/bytecodealliance/wasm-tools.git?rev=a2635eb91772d2de1607acbe14ff92ad16f25d33#a2635eb91772d2de1607acbe14ff92ad16f25d33"
+source = "git+https://github.com/bytecodealliance/wasm-tools.git?branch=wit-encoder-use#3f9d1d8c11723204946e122c2d86503e8a90ce2d"
 dependencies = [
  "pretty_assertions",
  "semver",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -97,7 +97,7 @@ dependencies = [
 [[package]]
 name = "wit-encoder"
 version = "0.212.0"
-source = "git+https://github.com/bytecodealliance/wasm-tools.git#a265ec17ab8ee9081e9390387eafda7d92107f27"
+source = "git+https://github.com/bytecodealliance/wasm-tools.git?rev=a265ec17ab8ee9081e9390387eafda7d92107f27#a265ec17ab8ee9081e9390387eafda7d92107f27"
 dependencies = [
  "pretty_assertions",
  "semver",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -13,7 +13,7 @@ anyhow = "1.0"
 heck = "0.5"
 itertools = "0.13"
 weedle = "0.13.0"
-wit-encoder = { git = "https://github.com/bytecodealliance/wasm-tools.git" }
+wit-encoder = { git = "https://github.com/bytecodealliance/wasm-tools.git", rev = "a265ec17ab8ee9081e9390387eafda7d92107f27" }
 
 [dev-dependencies]
 pretty_assertions = "1.4.0"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -12,8 +12,7 @@ crate-type = ["lib"]
 anyhow = "1.0"
 heck = "0.5"
 itertools = "0.13"
-# need https://github.com/rustwasm/weedle/pull/56
-weedle = { git = "https://github.com/rustwasm/weedle.git" }
+weedle = "0.13.0"
 wit-encoder = { git = "https://github.com/bytecodealliance/wasm-tools.git" }
 
 [dev-dependencies]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -14,7 +14,7 @@ heck = "0.5"
 itertools = "0.13"
 # need https://github.com/rustwasm/weedle/pull/56
 weedle = { git = "https://github.com/rustwasm/weedle.git" }
-wit-encoder = { git = "https://github.com/bytecodealliance/wasm-tools.git", branch = "wit-encoder-use" }
+wit-encoder = { git = "https://github.com/bytecodealliance/wasm-tools.git" }
 
 [dev-dependencies]
 pretty_assertions = "1.4.0"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -14,7 +14,7 @@ heck = "0.5"
 itertools = "0.13"
 # need https://github.com/rustwasm/weedle/pull/56
 weedle = { git = "https://github.com/rustwasm/weedle.git" }
-wit-encoder = { git = "https://github.com/bytecodealliance/wasm-tools.git", rev = "a2635eb91772d2de1607acbe14ff92ad16f25d33" }
+wit-encoder = { git = "https://github.com/bytecodealliance/wasm-tools.git", branch = "wit-encoder-use" }
 
 [dev-dependencies]
 pretty_assertions = "1.4.0"

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -2,3 +2,4 @@ mod translations;
 mod types_;
 
 pub use translations::{webidl_to_wit, ConversionOptions, HandleUnsupported};
+pub use wit_encoder::{Ident, PackageName};

--- a/src/translations.rs
+++ b/src/translations.rs
@@ -210,16 +210,16 @@ pub fn webidl_to_wit(
     package.interface(state.interface);
 
     for global_name in global_world_singletons {
-        let mut interface = Interface::new(global_name.clone());
+        let mut interface = Interface::new(format!("idl-{}", global_name));
         let mut use_ = Use::new(options.interface.clone());
-        use_.item("window", None);
+        use_.item(&global_name, None);
         interface.use_(use_);
         let mut func = StandaloneFunc::new(format!("get-{}", global_name));
-        func.results(wit_encoder::Type::named(Ident::new("window")));
+        func.results(wit_encoder::Type::named(Ident::new(global_name.clone())));
         interface.function(func);
         package.interface(interface);
         let mut world = World::new(global_name.clone());
-        world.named_interface_import(global_name.clone());
+        world.named_interface_import(format!("idl-{}", global_name));
         package.world(world);
     }
 

--- a/src/translations.rs
+++ b/src/translations.rs
@@ -3,7 +3,7 @@ use heck::{ToKebabCase, ToPascalCase, ToSnakeCase};
 use itertools::Itertools;
 use std::collections::{HashMap, HashSet};
 use weedle::{Definition, Definitions as WebIdlDefinitions};
-use wit_encoder::{Ident, Interface, StandaloneFunc, Use, World};
+use wit_encoder::{Ident, Interface, StandaloneFunc, World};
 
 /// conversion options.
 #[derive(Clone, Debug)]
@@ -30,7 +30,7 @@ pub enum HandleUnsupported {
 impl Default for ConversionOptions {
     fn default() -> Self {
         Self {
-            package_name: wit_encoder::PackageName::new("my-namespace", "my-package", None),
+            package_name: wit_encoder::PackageName::new("my-namespace", "my-package-idl", None),
             interface: "my-interface".into(),
             unsupported_features: HandleUnsupported::default(),
         }
@@ -207,21 +207,16 @@ pub fn webidl_to_wit(
         }
     }
 
-    package.interface(state.interface);
-
     for global_name in global_world_singletons {
-        let mut interface = Interface::new(format!("idl-{}", global_name));
-        let mut use_ = Use::new(options.interface.clone());
-        use_.item(&global_name, None);
-        interface.use_(use_);
         let mut func = StandaloneFunc::new(format!("get-{}", global_name));
         func.results(wit_encoder::Type::named(Ident::new(global_name.clone())));
-        interface.function(func);
-        package.interface(interface);
+        state.interface.function(func);
         let mut world = World::new(global_name.clone());
-        world.named_interface_import(format!("idl-{}", global_name));
+        world.named_interface_import(options.interface.clone());
         package.world(world);
     }
+
+    package.interface(state.interface);
 
     Ok(package)
 }

--- a/src/types_.rs
+++ b/src/types_.rs
@@ -55,9 +55,9 @@ impl<'a> State<'a> {
                     .items()
                     .iter()
                     .all(|dt| match dt {
-                        wit_encoder::InterfaceItem::TypeDef(dt) => dt.name(),
-                        wit_encoder::InterfaceItem::Function(func) => func.name(),
-                    } != &variant_name)
+                        wit_encoder::InterfaceItem::TypeDef(dt) => dt.name() != &variant_name,
+                        wit_encoder::InterfaceItem::Use(_) | wit_encoder::InterfaceItem::Function(_) => true,
+                    })
                 {
                     self.interface.type_def({
                         let cases = cases

--- a/src/types_.rs
+++ b/src/types_.rs
@@ -50,15 +50,11 @@ impl<'a> State<'a> {
                     .join("-or-");
                 let variant_name = ident_name(&variant_name);
 
-                if self
-                    .interface
-                    .items()
-                    .iter()
-                    .all(|dt| match dt {
-                        wit_encoder::InterfaceItem::TypeDef(dt) => dt.name() != &variant_name,
-                        wit_encoder::InterfaceItem::Use(_) | wit_encoder::InterfaceItem::Function(_) => true,
-                    })
-                {
+                if self.interface.items().iter().all(|dt| match dt {
+                    wit_encoder::InterfaceItem::TypeDef(dt) => dt.name() != &variant_name,
+                    wit_encoder::InterfaceItem::Use(_)
+                    | wit_encoder::InterfaceItem::Function(_) => true,
+                }) {
                     self.interface.type_def({
                         let cases = cases
                             .into_iter()

--- a/tests/inputs/borrow.wit
+++ b/tests/inputs/borrow.wit
@@ -1,4 +1,4 @@
-package my-namespace:my-package;
+package my-namespace:my-package-idl;
 
 interface my-interface {
   resource some-object {

--- a/tests/inputs/console.wit
+++ b/tests/inputs/console.wit
@@ -1,4 +1,4 @@
-package my-namespace:my-package;
+package my-namespace:my-package-idl;
 
 interface my-interface {
   resource console {

--- a/tests/inputs/enum.wit
+++ b/tests/inputs/enum.wit
@@ -1,4 +1,4 @@
-package my-namespace:my-package;
+package my-namespace:my-package-idl;
 
 interface my-interface {
   enum gpu-power-preference {

--- a/tests/inputs/record.wit
+++ b/tests/inputs/record.wit
@@ -1,4 +1,4 @@
-package my-namespace:my-package;
+package my-namespace:my-package-idl;
 
 interface my-interface {
   record gpu-color-dict {

--- a/tests/inputs/resource.wit
+++ b/tests/inputs/resource.wit
@@ -1,4 +1,4 @@
-package my-namespace:my-package;
+package my-namespace:my-package-idl;
 
 interface my-interface {
   resource gpu-pipeline-error {

--- a/tests/inputs/type.wit
+++ b/tests/inputs/type.wit
@@ -1,4 +1,4 @@
-package my-namespace:my-package;
+package my-namespace:my-package-idl;
 
 interface my-interface {
   type gpu-buffer-dynamic-offset = u32;

--- a/tests/inputs/unsupported.wit
+++ b/tests/inputs/unsupported.wit
@@ -1,4 +1,4 @@
-package my-namespace:my-package;
+package my-namespace:my-package-idl;
 
 interface my-interface {
   resource node-list {

--- a/tests/inputs/webgpu.wit
+++ b/tests/inputs/webgpu.wit
@@ -1,4 +1,4 @@
-package my-namespace:my-package;
+package my-namespace:my-package-idl;
 
 interface my-interface {
   record gpu-object-descriptor-base {

--- a/tests/inputs/window.idl
+++ b/tests/inputs/window.idl
@@ -3,7 +3,7 @@ interface Window : EventTarget {
   [LegacyUnforgeable] readonly attribute WindowProxy window;
   [Replaceable] readonly attribute WindowProxy self;
   // [LegacyUnforgeable] readonly attribute Document document;
-  attribute DOMString name; 
+  attribute DOMString name;
   // [PutForwards=href, LegacyUnforgeable] readonly attribute Location location;
   // readonly attribute History history;
   // readonly attribute Navigation navigation;
@@ -62,3 +62,4 @@ dictionary WindowPostMessageOptions : StructuredSerializeOptions {
 
 // hack
 typedef Window WindowProxy;
+

--- a/tests/inputs/window.idl
+++ b/tests/inputs/window.idl
@@ -2,18 +2,18 @@ interface Window : EventTarget {
   // the current browsing context
   [LegacyUnforgeable] readonly attribute WindowProxy window;
   [Replaceable] readonly attribute WindowProxy self;
-  [LegacyUnforgeable] readonly attribute Document document;
+  // [LegacyUnforgeable] readonly attribute Document document;
   attribute DOMString name; 
-  [PutForwards=href, LegacyUnforgeable] readonly attribute Location location;
-  readonly attribute History history;
-  readonly attribute Navigation navigation;
-  readonly attribute CustomElementRegistry customElements;
-  [Replaceable] readonly attribute BarProp locationbar;
-  [Replaceable] readonly attribute BarProp menubar;
-  [Replaceable] readonly attribute BarProp personalbar;
-  [Replaceable] readonly attribute BarProp scrollbars;
-  [Replaceable] readonly attribute BarProp statusbar;
-  [Replaceable] readonly attribute BarProp toolbar;
+  // [PutForwards=href, LegacyUnforgeable] readonly attribute Location location;
+  // readonly attribute History history;
+  // readonly attribute Navigation navigation;
+  // readonly attribute CustomElementRegistry customElements;
+  // [Replaceable] readonly attribute BarProp locationbar;
+  // [Replaceable] readonly attribute BarProp menubar;
+  // [Replaceable] readonly attribute BarProp personalbar;
+  // [Replaceable] readonly attribute BarProp scrollbars;
+  // [Replaceable] readonly attribute BarProp statusbar;
+  // [Replaceable] readonly attribute BarProp toolbar;
   attribute DOMString status;
   undefined close();
   readonly attribute boolean closed;
@@ -28,7 +28,7 @@ interface Window : EventTarget {
   // TODO
   // attribute any opener;
   [Replaceable] readonly attribute WindowProxy? parent;
-  readonly attribute Element? frameElement;
+  // readonly attribute Element? frameElement;
   WindowProxy? open(optional USVString url = "", optional DOMString target = "_blank", optional [LegacyNullToEmptyString] DOMString features = "");
 
   // Since this is the global object, the IDL named getter adds a NamedPropertiesObject exotic
@@ -38,12 +38,12 @@ interface Window : EventTarget {
   // getter object (DOMString name);
 
   // the user agent
-  readonly attribute Navigator navigator;
-  [Replaceable] readonly attribute Navigator clientInformation; // legacy alias of .navigator
+  // readonly attribute Navigator navigator;
+  // [Replaceable] readonly attribute Navigator clientInformation; // legacy alias of .navigator
   readonly attribute boolean originAgentCluster;
 
   // user prompts
-  undefined alert();
+  // undefined alert();
   undefined alert(DOMString message);
   boolean confirm(optional DOMString message = "");
   DOMString? prompt(optional DOMString message = "", optional DOMString default = "");
@@ -59,3 +59,6 @@ interface Window : EventTarget {
 dictionary WindowPostMessageOptions : StructuredSerializeOptions {
   USVString targetOrigin = "/";
 };
+
+// hack
+typedef Window WindowProxy;

--- a/tests/inputs/window.idl
+++ b/tests/inputs/window.idl
@@ -1,0 +1,61 @@
+interface Window : EventTarget {
+  // the current browsing context
+  [LegacyUnforgeable] readonly attribute WindowProxy window;
+  [Replaceable] readonly attribute WindowProxy self;
+  [LegacyUnforgeable] readonly attribute Document document;
+  attribute DOMString name; 
+  [PutForwards=href, LegacyUnforgeable] readonly attribute Location location;
+  readonly attribute History history;
+  readonly attribute Navigation navigation;
+  readonly attribute CustomElementRegistry customElements;
+  [Replaceable] readonly attribute BarProp locationbar;
+  [Replaceable] readonly attribute BarProp menubar;
+  [Replaceable] readonly attribute BarProp personalbar;
+  [Replaceable] readonly attribute BarProp scrollbars;
+  [Replaceable] readonly attribute BarProp statusbar;
+  [Replaceable] readonly attribute BarProp toolbar;
+  attribute DOMString status;
+  undefined close();
+  readonly attribute boolean closed;
+  undefined stop();
+  undefined focus();
+  undefined blur();
+
+  // other browsing contexts
+  [Replaceable] readonly attribute WindowProxy frames;
+  [Replaceable] readonly attribute unsigned long length;
+  [LegacyUnforgeable] readonly attribute WindowProxy? top;
+  // TODO
+  // attribute any opener;
+  [Replaceable] readonly attribute WindowProxy? parent;
+  readonly attribute Element? frameElement;
+  WindowProxy? open(optional USVString url = "", optional DOMString target = "_blank", optional [LegacyNullToEmptyString] DOMString features = "");
+
+  // Since this is the global object, the IDL named getter adds a NamedPropertiesObject exotic
+  // object on the prototype chain. Indeed, this does not make the global object an exotic object.
+  // Indexed access is taken care of by the WindowProxy exotic object.
+  // TODO
+  // getter object (DOMString name);
+
+  // the user agent
+  readonly attribute Navigator navigator;
+  [Replaceable] readonly attribute Navigator clientInformation; // legacy alias of .navigator
+  readonly attribute boolean originAgentCluster;
+
+  // user prompts
+  undefined alert();
+  undefined alert(DOMString message);
+  boolean confirm(optional DOMString message = "");
+  DOMString? prompt(optional DOMString message = "", optional DOMString default = "");
+  undefined print();
+
+  // TODO
+  // undefined postMessage(any message, USVString targetOrigin, optional sequence<object> transfer = []);
+  // undefined postMessage(any message, optional WindowPostMessageOptions options = {});
+
+  // also has obsolete members
+};
+
+dictionary WindowPostMessageOptions : StructuredSerializeOptions {
+  USVString targetOrigin = "/";
+};

--- a/tests/inputs/window.wit
+++ b/tests/inputs/window.wit
@@ -1,4 +1,8 @@
-package my-namespace:my-package;
+package my-namespace:my-package-idl;
+
+world window {
+  import my-interface;
+}
 
 interface my-interface {
   resource window {
@@ -28,13 +32,5 @@ interface my-interface {
     target-origin: option<string>,
   }
   type window-proxy = window;
-}
-
-interface idl-window {
-  use my-interface.{ window };
   get-window: func() -> window;
-}
-
-world window {
-  import idl-window;
 }

--- a/tests/inputs/window.wit
+++ b/tests/inputs/window.wit
@@ -4,19 +4,8 @@ interface my-interface {
   resource window {
     window: func() -> window-proxy;
     self: func() -> window-proxy;
-    document: func() -> document;
     name: func() -> string;
     set-name: func(name: string);
-    location: func() -> location;
-    history: func() -> history;
-    navigation: func() -> navigation;
-    custom-elements: func() -> custom-element-registry;
-    locationbar: func() -> bar-prop;
-    menubar: func() -> bar-prop;
-    personalbar: func() -> bar-prop;
-    scrollbars: func() -> bar-prop;
-    statusbar: func() -> bar-prop;
-    toolbar: func() -> bar-prop;
     status: func() -> string;
     set-status: func(status: string);
     close: func();
@@ -28,12 +17,8 @@ interface my-interface {
     length: func() -> u32;
     top: func() -> option<window-proxy>;
     parent: func() -> option<window-proxy>;
-    frame-element: func() -> option<element>;
     open: func(url: option<string>, target: option<string>, features: option<string>) -> option<window-proxy>;
-    navigator: func() -> navigator;
-    client-information: func() -> navigator;
     origin-agent-cluster: func() -> bool;
-    alert: func();
     alert: func(message: string);
     confirm: func(message: option<string>) -> bool;
     prompt: func(message: option<string>, default: option<string>) -> string;
@@ -42,13 +27,14 @@ interface my-interface {
   record window-post-message-options {
     target-origin: option<string>,
   }
+  type window-proxy = window;
 }
 
-interface window {
-  use my-interface.window;
+interface idl-window {
+  use my-interface.{ window };
   get-window: func() -> window;
 }
 
 world window {
-  import window;
+  import idl-window;
 }

--- a/tests/inputs/window.wit
+++ b/tests/inputs/window.wit
@@ -1,0 +1,54 @@
+package my-namespace:my-package;
+
+interface my-interface {
+  resource window {
+    window: func() -> window-proxy;
+    self: func() -> window-proxy;
+    document: func() -> document;
+    name: func() -> string;
+    set-name: func(name: string);
+    location: func() -> location;
+    history: func() -> history;
+    navigation: func() -> navigation;
+    custom-elements: func() -> custom-element-registry;
+    locationbar: func() -> bar-prop;
+    menubar: func() -> bar-prop;
+    personalbar: func() -> bar-prop;
+    scrollbars: func() -> bar-prop;
+    statusbar: func() -> bar-prop;
+    toolbar: func() -> bar-prop;
+    status: func() -> string;
+    set-status: func(status: string);
+    close: func();
+    closed: func() -> bool;
+    stop: func();
+    focus: func();
+    blur: func();
+    frames: func() -> window-proxy;
+    length: func() -> u32;
+    top: func() -> option<window-proxy>;
+    parent: func() -> option<window-proxy>;
+    frame-element: func() -> option<element>;
+    open: func(url: option<string>, target: option<string>, features: option<string>) -> option<window-proxy>;
+    navigator: func() -> navigator;
+    client-information: func() -> navigator;
+    origin-agent-cluster: func() -> bool;
+    alert: func();
+    alert: func(message: string);
+    confirm: func(message: option<string>) -> bool;
+    prompt: func(message: option<string>, default: option<string>) -> string;
+    print: func();
+  }
+  record window-post-message-options {
+    target-origin: option<string>,
+  }
+}
+
+interface window {
+  use my-interface.window;
+  get-window: func() -> window;
+}
+
+world window {
+  import window;
+}

--- a/tests/smoke.rs
+++ b/tests/smoke.rs
@@ -50,6 +50,11 @@ fn console() {
 }
 
 #[test]
+fn window() {
+    compare("window", Default::default());
+}
+
+#[test]
 fn unsupported() {
     compare(
         "unsupported",


### PR DESCRIPTION
This makes progress towards https://github.com/wasi-gfx/webidl2wit/issues/7 for a Jco shared top-level convention.

The way this works is that:

* Whenever one of the global singletons by name is found as an interface being defined, it adds a new function with the same name as that global - `get-[globalname]`.
* It defines a new world that imports this interface.

In addition, the default package name is changed from `my-package` to `my-package-idl` so that Jco can use the `-idl` suffix combined with the `--experimental-idl` flag to automatically handle IDL interfaces as attaching from the global object through the imported interface name.

I will document this exact convention further in the corresponding Jco PR, including how the global lookup replaces `-` with `.` from the interface name, but for now this PR should suffice to get a simple prototype together.
