### PR TITLE
feat: singleton interface mode

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -96,8 +96,9 @@ dependencies = [
 
 [[package]]
 name = "wit-encoder"
-version = "0.212.0"
-source = "git+https://github.com/bytecodealliance/wasm-tools.git?rev=a265ec17ab8ee9081e9390387eafda7d92107f27#a265ec17ab8ee9081e9390387eafda7d92107f27"
+version = "0.213.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "815d33c067884162abe12cb73486564be4d78c0e09c4b2be0efc13223392b5fa"
 dependencies = [
  "pretty_assertions",
  "semver",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -13,7 +13,7 @@ anyhow = "1.0"
 heck = "0.5"
 itertools = "0.13"
 weedle = "0.13.0"
-wit-encoder = { git = "https://github.com/bytecodealliance/wasm-tools.git", rev = "a265ec17ab8ee9081e9390387eafda7d92107f27" }
+wit-encoder = "0.213.0"
 
 [dev-dependencies]
 pretty_assertions = "1.4.0"

--- a/src/translations.rs
+++ b/src/translations.rs
@@ -16,7 +16,7 @@ pub struct ConversionOptions {
     ///
     /// When using the outputted wit in a JS environment, it is recommended that your package name starts or ends with idl.
     ///
-    /// This lets tools like JCO know that this wit represents bindings to built in functions.
+    /// This lets tools like Jco know that this wit represents bindings to built in functions.
     ///
     /// Example
     /// ```
@@ -33,6 +33,14 @@ pub struct ConversionOptions {
     pub interface_name: String,
     /// When set, treats the given interface name as a singleton, flattening
     /// its functions as top-level interface functions of an interface of the given name.
+    ///
+    /// When using the outputted wit in a JS environment, it is recommended to make this name
+    /// match the global name of the interface, with a `global-` prefix, for transparent runtime
+    /// support in Jco.
+    ///
+    /// For example, `globalThis.console` or `globalThis.navigator.gpu` could be reflected as
+    /// global-console or global-navigator-gpu respectively to automatically bind these to those
+    /// objects under --experimental-idl-imports
     pub singleton_interface: Option<String>,
     /// Skip unsupported features.
     pub unsupported_features: HandleUnsupported,

--- a/tests/inputs/console.wit
+++ b/tests/inputs/console.wit
@@ -1,25 +1,23 @@
 package my-namespace:my-package-idl;
 
 interface my-interface {
-  resource console {
-    assert: func(condition: option<bool>, data: list<string>);
-    clear: func();
-    debug: func(data: list<string>);
-    error: func(data: list<string>);
-    info: func(data: list<string>);
-    log: func(data: list<string>);
-    table: func(tabular-data: option<string>, properties: option<list<string>>);
-    trace: func(data: list<string>);
-    warn: func(data: list<string>);
-    dir: func(item: option<string>);
-    dirxml: func(data: list<string>);
-    count: func(label: option<string>);
-    count-reset: func(label: option<string>);
-    group: func(data: list<string>);
-    group-collapsed: func(data: list<string>);
-    group-end: func();
-    time: func(label: option<string>);
-    time-log: func(label: option<string>, data: list<string>);
-    time-end: func(label: option<string>);
-  }
+  assert: func(condition: option<bool>, data: list<string>);
+  clear: func();
+  debug: func(data: list<string>);
+  error: func(data: list<string>);
+  info: func(data: list<string>);
+  log: func(data: list<string>);
+  table: func(tabular-data: option<string>, properties: option<list<string>>);
+  trace: func(data: list<string>);
+  warn: func(data: list<string>);
+  dir: func(item: option<string>);
+  dirxml: func(data: list<string>);
+  count: func(label: option<string>);
+  count-reset: func(label: option<string>);
+  group: func(data: list<string>);
+  group-collapsed: func(data: list<string>);
+  group-end: func();
+  time: func(label: option<string>);
+  time-log: func(label: option<string>, data: list<string>);
+  time-end: func(label: option<string>);
 }

--- a/tests/inputs/custom-resources.wit
+++ b/tests/inputs/custom-resources.wit
@@ -263,8 +263,8 @@ interface my-interface {
     %u16(u16),
     %u32(u32),
     %u64(u64),
-    f32(f32),
-    f64(f64),
+    %f32(f32),
+    %f64(f64),
     %string(string),
   }
   resource object {

--- a/tests/inputs/unsupported.idl
+++ b/tests/inputs/unsupported.idl
@@ -2,7 +2,7 @@
 interface NodeList {
   getter Node? item(unsigned long index);
   readonly attribute unsigned long length;
-  iterable<Node>;
+  // iterable<Node>;
 };
 
 [Exposed=Window]

--- a/tests/inputs/unsupported.idl
+++ b/tests/inputs/unsupported.idl
@@ -2,7 +2,7 @@
 interface NodeList {
   getter Node? item(unsigned long index);
   readonly attribute unsigned long length;
-  // iterable<Node>;
+  iterable<Node>;
 };
 
 [Exposed=Window]

--- a/tests/inputs/unsupported.wit
+++ b/tests/inputs/unsupported.wit
@@ -44,7 +44,7 @@ interface my-interface {
   }
   variant bool-or-f64-or-string {
     %bool(bool),
-    f64(f64),
+    %f64(f64),
     %string(string),
   }
   resource html-unknown-element {

--- a/tests/inputs/webgpu.wit
+++ b/tests/inputs/webgpu.wit
@@ -455,8 +455,8 @@ interface my-interface {
     %u16(u16),
     %u32(u32),
     %u64(u64),
-    f32(f32),
-    f64(f64),
+    %f32(f32),
+    %f64(f64),
     %string(string),
   }
   resource object {
@@ -670,7 +670,7 @@ interface my-interface {
     snorm16x4,
     float16x2,
     float16x4,
-    %float32,
+    float32,
     float32x2,
     float32x3,
     float32x4,

--- a/tests/inputs/window.idl
+++ b/tests/inputs/window.idl
@@ -21,6 +21,8 @@ interface Window : EventTarget {
   undefined focus();
   undefined blur();
 
+  attribute DOMString type;
+
   // other browsing contexts
   [Replaceable] readonly attribute WindowProxy frames;
   [Replaceable] readonly attribute unsigned long length;

--- a/tests/inputs/window.wit
+++ b/tests/inputs/window.wit
@@ -17,6 +17,8 @@ interface my-interface {
     stop: func();
     focus: func();
     blur: func();
+    %type: func() -> string;
+    set-type: func(%type: string);
     frames: func() -> window-proxy;
     length: func() -> u32;
     top: func() -> option<window-proxy>;

--- a/tests/smoke.rs
+++ b/tests/smoke.rs
@@ -75,7 +75,7 @@ fn unsupported() {
     compare(
         "unsupported",
         ConversionOptions {
-            unsupported_features: HandleUnsupported::Bail,
+            unsupported_features: HandleUnsupported::Warn,
             ..Default::default()
         },
     );

--- a/tests/smoke.rs
+++ b/tests/smoke.rs
@@ -51,7 +51,13 @@ fn webgpu() {
 
 #[test]
 fn console() {
-    compare("console", Default::default());
+    compare(
+        "console",
+        ConversionOptions {
+            singleton_interface: Some("console".into()),
+            ..Default::default()
+        },
+    );
 }
 
 #[test]


### PR DESCRIPTION
As a follow-on to https://github.com/wasi-gfx/webidl2wit/pull/9, an alternative to the top-level `getWindow()` style of runtime API could be to define the top-level interface explicitly.

This PR adds a new option - `singleton_interface: Option<String>` which when set defines an interface that is a singleton that can be reflected as a WIT interface to be imported directly. Of course, this interface can't be a resource return for any other function when this is done. Validation should be included for that, but this PR doesn't currently include that as a simple initial implementation only.

With this approach, I'm able to use an interface name convention to define eg an interface name of `navigator-gpu` to mean that this interface object can be read of the global at that object position in the Jco convention, which seems like it can work well for a two-mode IDL binding convention for these different use cases, allowing the zero-runtime automatic nature of `--experimental-idl-imports` in Jco to also work for this convention in addition.

Feedback very welcome.