### PR TITLE
fixup: webidl: convention, latest wit-encoder

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -62,10 +62,68 @@ dependencies = [
 ]
 
 [[package]]
+name = "proc-macro2"
+version = "1.0.86"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5e719e8df665df0d1c8fbfd238015744736151d4445ec0836b8e628aae103b77"
+dependencies = [
+ "unicode-ident",
+]
+
+[[package]]
+name = "quote"
+version = "1.0.36"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0fa76aaf39101c457836aec0ce2316dbdc3ab723cdda1c6bd4e6ad4208acaca7"
+dependencies = [
+ "proc-macro2",
+]
+
+[[package]]
 name = "semver"
 version = "1.0.23"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "61697e0a1c7e512e84a621326239844a24d8207b4669b41bc18b32ea5cbf988b"
+dependencies = [
+ "serde",
+]
+
+[[package]]
+name = "serde"
+version = "1.0.204"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bc76f558e0cbb2a839d37354c575f1dc3fdc6546b5be373ba43d95f231bf7c12"
+dependencies = [
+ "serde_derive",
+]
+
+[[package]]
+name = "serde_derive"
+version = "1.0.204"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e0cd7e117be63d3c3678776753929474f3b04a43a080c744d6b0ae2a8c28e222"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn",
+]
+
+[[package]]
+name = "syn"
+version = "2.0.71"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b146dcf730474b4bcd16c311627b31ede9ab149045db4d6088b3becaea046462"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "unicode-ident",
+]
+
+[[package]]
+name = "unicode-ident"
+version = "1.0.12"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3354b9ac3fae1ff6755cb6db53683adb661634f67557942dea4facebec0fee4b"
 
 [[package]]
 name = "version_check"
@@ -96,12 +154,13 @@ dependencies = [
 
 [[package]]
 name = "wit-encoder"
-version = "0.213.0"
+version = "0.214.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "815d33c067884162abe12cb73486564be4d78c0e09c4b2be0efc13223392b5fa"
+checksum = "56024e6c0235a742909f0aff7bb0a4c6524d33a3aca59129a7db0f3320f975a1"
 dependencies = [
  "pretty_assertions",
  "semver",
+ "serde",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -13,7 +13,7 @@ anyhow = "1.0"
 heck = "0.5"
 itertools = "0.13"
 weedle = "0.13.0"
-wit-encoder = "0.213.0"
+wit-encoder = "0.214.0"
 
 [dev-dependencies]
 pretty_assertions = "1.4.0"

--- a/src/translations.rs
+++ b/src/translations.rs
@@ -13,21 +13,17 @@ use wit_encoder::{Ident, Interface, InterfaceItem, StandaloneFunc, World};
 pub struct ConversionOptions {
     /// Name of package for generated wit.
     ///
-    ///
-    /// When using the outputted wit in a JS environment, it is recommended that your package name starts or ends with idl.
+    /// When using the outputted wit in a JS environment, it is recommended to use the "webidl:"
+    /// namespace.
     ///
     /// This lets tools like Jco know that this wit represents bindings to built in functions.
     ///
     /// Example
     /// ```
     /// # use webidl2wit::PackageName;
-    /// PackageName::new("my-namespace", "my-package-idl", None);
+    /// PackageName::new("webidl", "my-package", None);
     /// ```
-    /// Or:
-    /// ```
-    /// # use webidl2wit::PackageName;
-    /// PackageName::new("my-namespace", "idl-my-package", None);
-    /// ```
+    ///
     pub package_name: crate::PackageName,
     /// Interface to hold the generated types and functions.
     pub interface_name: String,
@@ -38,9 +34,8 @@ pub struct ConversionOptions {
     /// match the global name of the interface, with a `global-` prefix, for transparent runtime
     /// support in Jco.
     ///
-    /// For example, `globalThis.console` or `globalThis.navigator.gpu` could be reflected as
-    /// global-console or global-navigator-gpu respectively to automatically bind these to those
-    /// objects under --experimental-idl-imports
+    /// For example in Jco, `globalThis.console` or `globalThis.navigator.gpu` can be reflected as
+    /// global-console or global-navigator-gpu respectively to automatically bind these globals.
     pub singleton_interface: Option<String>,
     /// Skip unsupported features.
     pub unsupported_features: HandleUnsupported,
@@ -62,7 +57,7 @@ pub enum HandleUnsupported {
 impl Default for ConversionOptions {
     fn default() -> Self {
         Self {
-            package_name: wit_encoder::PackageName::new("my-namespace", "my-package-idl", None),
+            package_name: wit_encoder::PackageName::new("webidl", "my-package-idl", None),
             interface_name: "my-interface".into(),
             unsupported_features: HandleUnsupported::default(),
             global_singletons: [

--- a/tests/inputs/borrow.wit
+++ b/tests/inputs/borrow.wit
@@ -1,4 +1,4 @@
-package my-namespace:my-package-idl;
+package webidl:my-package-idl;
 
 interface my-interface {
   resource some-object {

--- a/tests/inputs/console.wit
+++ b/tests/inputs/console.wit
@@ -1,4 +1,4 @@
-package my-namespace:my-package-idl;
+package webidl:my-package-idl;
 
 interface my-interface {
   assert: func(condition: option<bool>, data: list<string>);

--- a/tests/inputs/custom-resources.wit
+++ b/tests/inputs/custom-resources.wit
@@ -1,4 +1,4 @@
-package my-namespace:my-package-idl;
+package webidl:my-package-idl;
 
 interface my-interface {
   resource record-s32 {

--- a/tests/inputs/enum.wit
+++ b/tests/inputs/enum.wit
@@ -1,4 +1,4 @@
-package my-namespace:my-package-idl;
+package webidl:my-package-idl;
 
 interface my-interface {
   enum gpu-power-preference {

--- a/tests/inputs/order.wit
+++ b/tests/inputs/order.wit
@@ -1,4 +1,4 @@
-package my-namespace:my-package-idl;
+package webidl:my-package-idl;
 
 interface my-interface {
   resource partial-main {

--- a/tests/inputs/record.wit
+++ b/tests/inputs/record.wit
@@ -1,4 +1,4 @@
-package my-namespace:my-package-idl;
+package webidl:my-package-idl;
 
 interface my-interface {
   record gpu-color-dict {

--- a/tests/inputs/resource.wit
+++ b/tests/inputs/resource.wit
@@ -1,4 +1,4 @@
-package my-namespace:my-package-idl;
+package webidl:my-package-idl;
 
 interface my-interface {
   resource gpu-pipeline-error {

--- a/tests/inputs/type.wit
+++ b/tests/inputs/type.wit
@@ -1,4 +1,4 @@
-package my-namespace:my-package-idl;
+package webidl:my-package-idl;
 
 interface my-interface {
   type gpu-buffer-dynamic-offset = u32;

--- a/tests/inputs/unsupported.wit
+++ b/tests/inputs/unsupported.wit
@@ -1,4 +1,4 @@
-package my-namespace:my-package-idl;
+package webidl:my-package-idl;
 
 interface my-interface {
   resource node-list {

--- a/tests/inputs/webgpu.wit
+++ b/tests/inputs/webgpu.wit
@@ -1,4 +1,4 @@
-package my-namespace:my-package-idl;
+package webidl:my-package-idl;
 
 interface my-interface {
   record gpu-object-descriptor-base {

--- a/tests/inputs/window.wit
+++ b/tests/inputs/window.wit
@@ -1,4 +1,4 @@
-package my-namespace:my-package-idl;
+package webidl:my-package-idl;
 
 world window {
   import my-interface;


### PR DESCRIPTION
This adds the new `webidl:` namespacing convention as the default instead of the `idl-` package name suffix and prefix.

Also updated the convention docs slightly - I'm going to rather disable the flag in Jco and make this the default convention behaviour for the `webidl:` namespace, where the convention can be disabled instead by providing an alternative import mapping at transpilation time.