### PR TITLE
refactor: only warn if the output path already exists

### DIFF
--- a/crates/webidl2wit-cli/src/main.rs
+++ b/crates/webidl2wit-cli/src/main.rs
@@ -80,10 +80,13 @@ fn main() -> Result<()> {
         bail!("missing path [{}]", webidl_path.display());
     }
 
-    // Ensure the output path does not already exist
+    // Print a warning if the output path already exists
     if let Some(ref p) = wit_path {
         if std::fs::exists(p)? {
-            bail!("output path [{}] already exists", p.display());
+            eprintln!(
+                "output path [{}] already exists, overwriting...",
+                p.display()
+            );
         }
     }
 


### PR DESCRIPTION
Since overwriting existing auto-generated files (and checking them into source control) is a common use case, this commit makes sure the CLI doesn't fail when producing output.