### PR TITLE
fix: recognize void keywords in member fn results

### DIFF
--- a/crates/webidl2wit-cli/tests/fixtures/book-store.webidl
+++ b/crates/webidl2wit-cli/tests/fixtures/book-store.webidl
@@ -49,7 +49,7 @@ partial interface Library {
   readonly attribute LibraryName libraryName;
 
   // Rename this library
-  undefined renameLibrary(LibraryName newName);
+  renameLibrary(LibraryName newName);
 };
 
 typedef LibraryName DOMString;
@@ -59,5 +59,5 @@ interface BookManager {
   readonly attribute Library library;
 
   // Initialize a library
-  undefined initLibrary(LibraryName name);
+  initLibrary(LibraryName name);
 };

--- a/crates/webidl2wit-cli/tests/fixtures/book-store.webidl
+++ b/crates/webidl2wit-cli/tests/fixtures/book-store.webidl
@@ -49,7 +49,7 @@ partial interface Library {
   readonly attribute LibraryName libraryName;
 
   // Rename this library
-  void renameLibrary(LibraryName newName);
+  undefined renameLibrary(LibraryName newName);
 };
 
 typedef LibraryName DOMString;
@@ -59,5 +59,5 @@ interface BookManager {
   readonly attribute Library library;
 
   // Initialize a library
-  void initLibrary(LibraryName name);
+  undefined initLibrary(LibraryName name);
 };


### PR DESCRIPTION
This commit fixes an issue where `void` could be a return type in member functions (ex. in an Interface) and was being recognized as a type.

This leads to WIT thinking that `void` is a type that should have been defined elsewhere