### PR TITLE
Create CONTRIBUTING.md

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,0 +1,12 @@
+# Contributing
+
+Thanks for contributing to webidl2wit, we really appreciate your help!
+
+When adding new features, please discuss the change you wish to make via issues before opening a PR.
+
+PRs for bug fixes and minor improvements can be opened directly without opening an issue first.
+
+## Before Opening a PR
+
+* Make sure that `cargo test` passes.
+* Make sure that `cargo fmt --check` passes.


### PR DESCRIPTION
CONTRIBUTING.md is required for moving to the BA https://github.com/bytecodealliance/governance/blob/main/templates/projects/proposal-hosted-project.md#contributor-documentation